### PR TITLE
chore: update validation i18n keys in schemas and update error handling

### DIFF
--- a/docs/adr/0001-validation-i18n-keys.md
+++ b/docs/adr/0001-validation-i18n-keys.md
@@ -1,0 +1,67 @@
+# ADR 0001: Validation i18n via static keys in schemas
+
+## Status
+
+Accepted
+
+## Context
+
+Request validation uses Zod. Failed parses become `UnprocessableEntityError` with field-level messages that must be:
+
+- **Localized** in API responses (`Accept-Language` / i18next)
+- **Stable** in logs and observability (language-neutral identifiers, not client-facing copy)
+
+Several approaches were considered:
+
+| Approach                                                      | Problem                                                                                                          |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Zod built-in locales (`z.config(z.locales.tr())`) per request | Localizes at parse time → localized strings in logs; `z.config()` is process-global and unsafe under concurrency |
+| `req.t()` in dynamic schema factories                         | Same as above: translated strings stored before the error handler; couples schemas to HTTP/i18next               |
+| Custom keys in schemas + `req.t()` in error handler           | Keys in internal layer; translation only at the presentation edge                                                |
+
+Most validators (Zod, Valibot, Joi, Yup) expose a single `message` string that conflates error identity with user-facing copy. Separating those concerns is an application-level choice, not something libraries enforce.
+
+## Decision
+
+1. **Schemas store i18n translation keys only** — use `ParseKeys` and `'validation.*'` keys in Zod error params, not rendered text.
+2. **Translate once in the error handler** — `error-handler.middleware.ts` calls `req.t()` on `detail` and `errors[].message` before sending `application/problem+json`.
+3. **Do not use Zod locales or per-request `z.config()`** in validate middleware.
+4. **Log before translation** — `res.locals.error` and structured logs retain keys; clients receive translated responses.
+
+Example:
+
+```ts
+name: z.string('validation.sample.nameRequired' satisfies ParseKeys).min(
+  1,
+  'validation.sample.nameRequired' satisfies ParseKeys,
+);
+```
+
+Keys live in `locales/{lang}/translation.json`.
+
+## Consequences
+
+### Positive
+
+- Single presentation layer for validation copy (error handler)
+- Logs and alerts use stable keys regardless of request language
+- No global Zod locale mutation per request
+- Schemas remain usable outside HTTP (tests, scripts) without injecting `TFunction`
+
+### Negative
+
+- Every user-facing failure path needs an explicit key in the schema (or a shared Zod issue → key map)
+- Native Zod default messages are not used; omitting a key can leak English fallback text
+- Slightly more boilerplate than relying on Zod locales for generic rules (`min`, `max`, `invalid_type`)
+
+## Alternatives considered
+
+- **Structured field errors** (`{ field, code, params }`) with translation from issue metadata — better for logging/search, but a larger type and API change; deferred.
+- **Per-parse Zod `error` map with `req.t()`** — still pre-localizes messages unless the map returns keys; does not fix logging on its own.
+
+## References
+
+- [Zod error customization](https://zod.dev/error-customization)
+- `src/middleware/validate.middleware.ts`
+- `src/middleware/error-handler.middleware.ts`
+- `src/schemas/sample.schema.ts`

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -11,7 +11,12 @@
   "validation": {
     "sample": {
       "invalidId": "Invalid sample ID",
-      "nameRequired": "Name is required"
+      "nameRequired": "Name is required",
+      "pageInvalid": "Page must be a number",
+      "pageMin": "Page must be at least 1",
+      "limitInvalid": "Limit must be a number",
+      "limitMin": "Limit must be at least 1",
+      "limitMax": "Limit must be at most 100"
     }
   }
 }

--- a/locales/tr/translation.json
+++ b/locales/tr/translation.json
@@ -11,7 +11,12 @@
   "validation": {
     "sample": {
       "invalidId": "Geçersiz örnek ID",
-      "nameRequired": "İsim zorunludur"
+      "nameRequired": "İsim zorunludur",
+      "pageInvalid": "Sayfa bir sayı olmalıdır",
+      "pageMin": "Sayfa en az 1 olmalıdır",
+      "limitInvalid": "Limit bir sayı olmalıdır",
+      "limitMin": "Limit en az 1 olmalıdır",
+      "limitMax": "Limit en fazla 100 olmalıdır"
     }
   }
 }

--- a/src/middleware/error-handler.middleware.ts
+++ b/src/middleware/error-handler.middleware.ts
@@ -34,16 +34,14 @@ export const errorHandler: ErrorRequestHandler<unknown, ProblemDetail> = (err, r
   // Store error in teh locals object for detailed logging
   res.locals.error = loggableObject;
 
-  // Translate user-facing fields
-  problemDetail.detail = req.t(error.message as unknown as ParseKeys);
+  // Translate user-facing fields (validation messages are i18n keys until this point)
+  problemDetail.detail = req.t(error.message as ParseKeys);
 
-  if (isUnprocessableEntityError(error)) {
-    if (Array.isArray(problemDetail.errors)) {
-      problemDetail.errors = (problemDetail.errors as FieldError[]).map((error) => ({
-        ...error,
-        message: req.t(error.message as unknown as ParseKeys),
-      }));
-    }
+  if (isUnprocessableEntityError(error) && Array.isArray(problemDetail.errors)) {
+    problemDetail.errors = (problemDetail.errors as FieldError[]).map((fieldError) => ({
+      ...fieldError,
+      message: req.t(fieldError.message as ParseKeys),
+    }));
   }
 
   // Mask internal server errors in production

--- a/src/middleware/validate.middleware.ts
+++ b/src/middleware/validate.middleware.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from 'express';
 import type { ParseKeys } from 'i18next';
-import { z } from 'zod';
+import type { z } from 'zod';
 
 import { transformZodIssueToFieldError, UnprocessableEntityError } from '@/lib/error';
 import type { TValidationMap } from '@/types';
@@ -13,16 +13,13 @@ type TValidateOptions<T> = {
 
 export function validate<T>({ validationMap, schema }: TValidateOptions<T>): RequestHandler {
   return (req, _res, next) => {
-    // Set Zod's locale based on the detected request language
-    setZodLocale(req.language);
-
     parseWithZod({
       object: req[validationMap],
       schema,
       onError: (error) => {
         throw new UnprocessableEntityError(
           'common.validationFailed' satisfies ParseKeys,
-          error.issues.map((issue) => transformZodIssueToFieldError(issue)),
+          error.issues.map(transformZodIssueToFieldError),
         );
       },
       onSuccess: (data) => {
@@ -42,23 +39,4 @@ export function validate<T>({ validationMap, schema }: TValidateOptions<T>): Req
       },
     });
   };
-}
-
-/**
- * Set Zod locale based on request language.
- * Uses Zod v4's built-in locale system.
- */
-function setZodLocale(language: string): void {
-  /**
-   * Map i18next language codes to Zod locale functions
-   */
-  const localeMap: Record<string, () => ReturnType<typeof z.locales.en>> = {
-    tr: z.locales.tr,
-    en: z.locales.en,
-  };
-
-  const localeConfig = localeMap[language] ?? localeMap['en'];
-  if (localeConfig) {
-    z.config(localeConfig());
-  }
 }

--- a/src/schemas/sample.schema.ts
+++ b/src/schemas/sample.schema.ts
@@ -2,25 +2,37 @@ import type { ParseKeys } from 'i18next';
 import { z } from 'zod';
 
 /**
- * Note: Custom error messages use i18n translation keys.
- * These keys are translated in the validate middleware using req.t().
- * Keys must exist in locales/{lang}/translation.json
+ * Validation error messages are i18n keys (`ParseKeys`), translated in the error handler.
+ * @see docs/adr/0001-validation-i18n-keys.md
  */
 export const sampleIdParamsSchema = z.object({
   id: z.uuid('validation.sample.invalidId' satisfies ParseKeys),
 });
 
 export const getSamplesQuerySchema = z.object({
-  page: z.coerce.number().min(1).optional(),
-  limit: z.coerce.number().min(1).max(100).optional(),
+  page: z.coerce
+    .number('validation.sample.pageInvalid' satisfies ParseKeys)
+    .min(1, 'validation.sample.pageMin' satisfies ParseKeys)
+    .default(1)
+    .optional(),
+  limit: z.coerce
+    .number('validation.sample.limitInvalid' satisfies ParseKeys)
+    .min(1, 'validation.sample.limitMin' satisfies ParseKeys)
+    .max(100, 'validation.sample.limitMax' satisfies ParseKeys)
+    .default(10)
+    .optional(),
 });
 
 export const createSampleRequestBodySchema = z.object({
-  name: z.string().min(1, 'validation.sample.nameRequired' satisfies ParseKeys),
+  name: z
+    .string('validation.sample.nameRequired' satisfies ParseKeys)
+    .min(1, 'validation.sample.nameRequired' satisfies ParseKeys),
 });
 
 export const updateSampleRequestBodySchema = z.object({
-  name: z.string().min(1, 'validation.sample.nameRequired' satisfies ParseKeys),
+  name: z
+    .string('validation.sample.nameRequired' satisfies ParseKeys)
+    .min(1, 'validation.sample.nameRequired' satisfies ParseKeys),
 });
 
 export type TSampleIdParams = z.infer<typeof sampleIdParamsSchema>;


### PR DESCRIPTION
## 🗒️ Description

* Introduced ADR 0001 for validation i18n using static keys in schemas.
* Updated error handler to translate validation messages using i18n keys.
* Enhanced sample schemas to utilize new validation keys for better localization.
* Added new validation messages in English and Turkish translation files.

## ℹ️ Related Issue

<!--- If your pull request is related to any issue, mention it here with the issue number -->

## ✅ Checklist

<!--- Go through the following checklist and mark the ones that apply. Remove any that do not apply. -->

- [ ] I have tested the changes locally and they work as expected.
- [ ] My code follows the project's coding conventions and style guidelines.
- [ ] I have ensured that there are no linting or formatting errors.
- [ ] All existing tests pass and I have added new tests where necessary.
- [ ] I have updated the documentation if applicable.

## 🧪 How to Test

<!-- Steps for reviewers to test your work -->

## 📸 Screenshots

<!-- Attach screenshots if it helps -->
